### PR TITLE
Long string test passes

### DIFF
--- a/.rspec
+++ b/.rspec
@@ -1,3 +1,1 @@
-require spec_helper
-require format-documentation
-require fail-fast
+--require spec_helper

--- a/lib/Diary.rb
+++ b/lib/Diary.rb
@@ -11,8 +11,8 @@ class Diary
             return string
         end
 
-        if arr.length = 0
-            return 'No entries'
+        if arr.length > 5
+            return arr[0..4].join(" ") + " ..."
         end
     end
 end

--- a/spec/Diary_spec.rb
+++ b/spec/Diary_spec.rb
@@ -10,10 +10,11 @@ RSpec.describe Diary do
             diary = Diary.new
             expect(diary.make_snippet("This is a string")).to eq "This is a string"
         end
-
-    # Puts out fail message if string is empty
-    it 'If no entries found, returns "No entries"' do
-        diary = Diary.new
-        expect{diary.make_snippet('')}.to raise_error "No entries"
-    end
+    
+    context "Long string entered"
+        it "String longer than 5 words, returns string then ..." do
+            diary = Diary.new
+            expect(diary.make_snippet("This is a longer string than before")).to eq "This is a longer string ..."
+        end
+    
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -14,6 +14,9 @@
 #
 # See https://rubydoc.info/gems/rspec-core/RSpec/Core/Configuration
 RSpec.configure do |config|
+  config.color = true
+  config.formatter = :documentation
+  config.order = 'default'
   # rspec-expectations config goes here. You can use an alternate
   # assertion/expectation library such as wrong or the stdlib/minitest
   # assertions if you prefer.


### PR DESCRIPTION
Removed failing 'blank string' test
Short string test passes
Long string test passes

Updated RSpec to be format-documentation and fail-fast